### PR TITLE
Remove dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Tulip = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
-VegaLite = "112f6efa-9a02-5b7d-90c0-432ed331239a"
 
 [compat]
 Distances = "0.9.0, 0.10"


### PR DESCRIPTION
https://github.com/zsteve/OptimalTransport.jl/pull/22 added dependencies that should not be part of Project.toml, as mentioned in https://github.com/zsteve/OptimalTransport.jl/pull/22#discussion_r540809649. Also no compat bounds were added for these dependencies, and therefore new releases would not be merged into the package registry.

Maybe these dependencies are needed for the examples? In this case, a separate Project.toml (and probably even a Manifest.toml to make the notebooks reproducible) should be added to `examples`. (Apart from that, the notebooks could be created with Literate or Weave which would make it easy to export them to different formats and to include them in the documentation.)