### PR TITLE
Fix compat bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Distances = "0.9.0, 0.10"
 FillArrays = "0.9"
 IterativeSolvers = "0.8.4"
 MathOptInterface = "0.9"
-LazyArrays = ">= 0.18"
+LazyArrays = "0.18, 0.19"
 Requires = "1.1"
 julia = "1"
 


### PR DESCRIPTION
Compat bounds have to be upper bounded otherwise a new version won't be made available in the Julia package registry. One has to list the supported versions explicitly if they are breaking according to the Julia semver system (BTW is there a reason to support LazyArrays 0.18 as well?).