### PR TITLE
Use BlueStyle

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style="blue"

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,24 @@
+name: Format
+
+on:
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - name: Format code
+        run: |
+          using Pkg
+          Pkg.add(; name="JuliaFormatter", uuid="98e50ef6-434e-11e9-1051-2b60c6c9e899")
+          using JuliaFormatter
+          format("."; verbose=true)
+        shell: julia --color=yes {0}
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: JuliaFormatter
+          fail_on_error: true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![CI](https://github.com/zsteve/OptimalTransport.jl/workflows/CI/badge.svg?branch=master)](https://github.com/zsteve/OptimalTransport.jl/actions?query=workflow%3ACI+branch%3Amaster)
 [![Codecov](https://codecov.io/gh/zsteve/OptimalTransport.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/zsteve/OptimalTransport.jl)
 [![Coveralls](https://coveralls.io/repos/github/zsteve/OptimalTransport.jl/badge.svg?branch=master)](https://coveralls.io/github/zsteve/OptimalTransport.jl?branch=master)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
 This package provides some [Julia](https://julialang.org/) implementations of algorithms for computational [optimal transport](https://optimaltransport.github.io/), including the Earth-Mover's (Wasserstein) distance, Sinkhorn scaling algorithm for entropy-regularised transport as well as some variants or extensions. 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using OptimalTransport
-import Literate
-import Pkg
+using Literate: Literate
+using Pkg: Pkg
 
 if haskey(ENV, "GITHUB_ACTIONS")
     # Print `@debug` statements (https://github.com/JuliaDocs/Documenter.jl/issues/955)
@@ -75,6 +75,4 @@ makedocs(;
     checkdocs=:exports,
 )
 
-deploydocs(;
-    repo="github.com/zsteve/OptimalTransport.jl", push_preview=true,       
-)
+deploydocs(; repo="github.com/zsteve/OptimalTransport.jl", push_preview=true)

--- a/examples/basic/script.jl
+++ b/examples/basic/script.jl
@@ -21,11 +21,11 @@ Random.seed!(1234);
 # and $\nu$ (target measure) in 1D:
 
 M = 200
-μ = fill(1/M, M)
+μ = fill(1 / M, M)
 μsupport = rand(M)
 
 N = 250
-ν = fill(1/N, N)
+ν = fill(1 / N, N)
 νsupport = rand(N);
 
 # Now we compute the quadratic cost matrix $C_{ij} = \| x_i - x_j \|_2^2$:
@@ -133,11 +133,11 @@ norm(γ - γpot, Inf)
 # We construct two random measures, now with different total masses:
 
 M = 100
-μ = fill(1/M, M)
+μ = fill(1 / M, M)
 μsupport = rand(M)
 
 N = 200
-ν = fill(1/M, N)
+ν = fill(1 / M, N)
 νsupport = rand(N);
 
 # We compute the quadratic cost matrix:
@@ -164,9 +164,9 @@ norm(γ - γpot, Inf)
 
 μsupport = νsupport = range(-2, 2; length=100)
 C = pairwise(SqEuclidean(), μsupport', νsupport')
-μ = exp.(- μsupport.^2 ./ 0.5^2)
+μ = exp.(-μsupport .^ 2 ./ 0.5^2)
 μ ./= sum(μ)
-ν = νsupport.^2 .* exp.(- νsupport.^2 ./ 0.5^2)
+ν = νsupport .^ 2 .* exp.(-νsupport .^ 2 ./ 0.5^2)
 ν ./= sum(ν)
 
 plot(μsupport, μ; label=raw"$\mu$", size=(600, 400))
@@ -176,8 +176,11 @@ plot!(νsupport, ν; label=raw"$\nu$")
 
 γ = sinkhorn(μ, ν, C, 0.01)
 heatmap(
-    μsupport, νsupport, γ;
-    title="Entropically regularised optimal transport", size=(600, 600)
+    μsupport,
+    νsupport,
+    γ;
+    title="Entropically regularised optimal transport",
+    size=(600, 600),
 )
 
 # ### Quadratically regularised transport
@@ -187,8 +190,11 @@ heatmap(
 
 γquad = Matrix(quadreg(μ, ν, C, 5; maxiter=500))
 heatmap(
-    μsupport, νsupport, γquad;
-    title="Quadratically regularised optimal transport", size=(600, 600)
+    μsupport,
+    νsupport,
+    γquad;
+    title="Quadratically regularised optimal transport",
+    size=(600, 600),
 )
 
 # ### Sinkhorn barycenters
@@ -208,9 +214,9 @@ heatmap(
 # $\lambda_1 \in \{0.25, 0.5, 0.75\}$.
 
 support = range(-1, 1; length=250)
-mu1 = exp.(- (support .+ 0.5).^2 ./ 0.1^2)
+mu1 = exp.(-(support .+ 0.5) .^ 2 ./ 0.1^2)
 mu1 ./= sum(mu1)
-mu2 = exp.(- (support .- 0.5).^2 ./ 0.1^2)
+mu2 = exp.(-(support .- 0.5) .^ 2 ./ 0.1^2)
 mu2 ./= sum(mu2)
 
 plt = plot(; size=(800, 400), legend=:outertopright)

--- a/src/pot.jl
+++ b/src/pot.jl
@@ -5,7 +5,7 @@ using ..PyCall
 const pot = PyNULL()
 
 function __init__()
-    copy!(pot, pyimport_conda("ot", "pot", "conda-forge"))
+    return copy!(pot, pyimport_conda("ot", "pot", "conda-forge"))
 end
 
 """
@@ -61,8 +61,17 @@ This function is a wrapper of the function
 [`sinkhorn`](https://pythonot.github.io/all.html?highlight=sinkhorn#ot.sinkhorn) in the
 Python Optimal Transport package.
 """
-function sinkhorn(mu, nu, C, eps; tol=1e-9, max_iter = 1000, method = "sinkhorn", verbose = false)
-    return pot.sinkhorn(nu, mu, PyReverseDims(C), eps; stopThr = tol, numItermax = max_iter, method = method, verbose = verbose)'
+function sinkhorn(mu, nu, C, eps; tol=1e-9, max_iter=1000, method="sinkhorn", verbose=false)
+    return pot.sinkhorn(
+        nu,
+        mu,
+        PyReverseDims(C),
+        eps;
+        stopThr=tol,
+        numItermax=max_iter,
+        method=method,
+        verbose=verbose,
+    )'
 end
 
 """
@@ -78,8 +87,19 @@ This function is a wrapper of the function
 [`sinkhorn2`](https://pythonot.github.io/all.html?highlight=sinkhorn#ot.sinkhorn2) in the
 Python Optimal Transport package.
 """
-function sinkhorn2(mu, nu, C, eps; tol=1e-9, max_iter = 1000, method = "sinkhorn", verbose = false)
-    return pot.sinkhorn2(nu, mu, PyReverseDims(C), eps; stopThr = tol, numItermax = max_iter, method = method, verbose = verbose)[1]
+function sinkhorn2(
+    mu, nu, C, eps; tol=1e-9, max_iter=1000, method="sinkhorn", verbose=false
+)
+    return pot.sinkhorn2(
+        nu,
+        mu,
+        PyReverseDims(C),
+        eps;
+        stopThr=tol,
+        numItermax=max_iter,
+        method=method,
+        verbose=verbose,
+    )[1]
 end
 
 """
@@ -92,8 +112,20 @@ This function is a wrapper of the function
 [`sinkhorn_unbalanced`](https://pythonot.github.io/all.html?highlight=sinkhorn_unbalanced#ot.sinkhorn_unbalanced)
 in the Python Optimal Transport package.
 """
-function sinkhorn_unbalanced(mu, nu, C, eps, lambda; tol = 1e-9, max_iter = 1000, method = "sinkhorn", verbose = false)
-    return pot.sinkhorn_unbalanced(nu, mu, PyReverseDims(C), eps, lambda; stopThr = tol, numItermax = max_iter, method = method, verbose = verbose)'
+function sinkhorn_unbalanced(
+    mu, nu, C, eps, lambda; tol=1e-9, max_iter=1000, method="sinkhorn", verbose=false
+)
+    return pot.sinkhorn_unbalanced(
+        nu,
+        mu,
+        PyReverseDims(C),
+        eps,
+        lambda;
+        stopThr=tol,
+        numItermax=max_iter,
+        method=method,
+        verbose=verbose,
+    )'
 end
 
 """
@@ -106,8 +138,20 @@ This function is a wrapper of the function
 [`sinkhorn_unbalanced2`](https://pythonot.github.io/all.html#ot.sinkhorn_unbalanced2) in
 the Python Optimal Transport package.
 """
-function sinkhorn_unbalanced2(mu, nu, C, eps, lambda; tol = 1e-9, max_iter = 1000, method = "sinkhorn", verbose = false)
-    return pot.sinkhorn_unbalanced2(nu, mu, PyReverseDims(C), eps, lambda; stopThr = tol, numItermax = max_iter, method = method, verbose = verbose)[1]
+function sinkhorn_unbalanced2(
+    mu, nu, C, eps, lambda; tol=1e-9, max_iter=1000, method="sinkhorn", verbose=false
+)
+    return pot.sinkhorn_unbalanced2(
+        nu,
+        mu,
+        PyReverseDims(C),
+        eps,
+        lambda;
+        stopThr=tol,
+        numItermax=max_iter,
+        method=method,
+        verbose=verbose,
+    )[1]
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ Random.seed!(100)
     ν ./= sum(ν)
 
     # create random cost matrix
-    C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims = 2)
+    C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
 
     # compute optimal transport map and cost with POT
     pot_P = POT.emd(μ, ν, C)
@@ -38,9 +38,9 @@ Random.seed!(100)
 
     lp = Tulip.Optimizer()
     cost = emd2(μ, ν, C, lp)
-    @test dot(C, P) ≈ cost atol=1e-5
+    @test dot(C, P) ≈ cost atol = 1e-5
     @test MOI.get(lp, MOI.TerminationStatus()) == MOI.OPTIMAL
-    @test cost ≈ pot_cost atol=1e-5
+    @test cost ≈ pot_cost atol = 1e-5
 end
 
 @testset "entropically regularized transport" begin
@@ -49,11 +49,11 @@ end
 
     @testset "example" begin
         # create two uniform histograms
-        μ = fill(1/M, M)
-        ν = fill(1/N, N)
+        μ = fill(1 / M, M)
+        ν = fill(1 / N, N)
 
         # create random cost matrix
-        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims = 2)
+        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
 
         # compute optimal transport map (Julia implementation + POT)
         eps = 0.01
@@ -64,17 +64,17 @@ end
         # compute optimal transport cost (Julia implementation + POT)
         c = sinkhorn2(μ, ν, C, eps)
         c_pot = POT.sinkhorn2(μ, ν, C, eps)
-        @test c ≈ c_pot atol=1e-9
+        @test c ≈ c_pot atol = 1e-9
     end
 
     # different element type
     @testset "Float32" begin
         # create two uniform histograms
-        μ = fill(Float32(1/M), M)
-        ν = fill(Float32(1/N), N)
+        μ = fill(Float32(1 / M), M)
+        ν = fill(Float32(1 / N), N)
 
         # create random cost matrix
-        C = pairwise(SqEuclidean(), rand(Float32, 1, M), rand(Float32, 1, N); dims = 2)
+        C = pairwise(SqEuclidean(), rand(Float32, 1, M), rand(Float32, 1, N); dims=2)
 
         # compute optimal transport map (Julia implementation + POT)
         eps = 0.01f0
@@ -91,15 +91,15 @@ end
 
         c_pot = POT.sinkhorn2(μ, ν, C, eps)
         @test c_pot isa Float64 # POT does not respect input types
-        @test c ≈ c_pot atol=Base.eps(Float32)
+        @test c ≈ c_pot atol = Base.eps(Float32)
     end
 
     # computation on the GPU
     if CUDA.functional()
         @testset "CUDA" begin
             # create two uniform histograms
-            μ = CUDA.fill(Float32(1/M), M)
-            ν = CUDA.fill(Float32(1/N), N)
+            μ = CUDA.fill(Float32(1 / M), M)
+            ν = CUDA.fill(Float32(1 / N), N)
 
             # create random cost matrix
             C = abs2.(CUDA.rand(M) .- CUDA.rand(1, N))
@@ -120,10 +120,10 @@ end
     M = 250
     N = 200
     @testset "example" begin
-        μ = fill(1/N, M)
-        ν = fill(1/N, N)
-        
-        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims = 2)
+        μ = fill(1 / N, M)
+        ν = fill(1 / N, N)
+
+        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
 
         eps = 0.01
         lambda = 1
@@ -136,10 +136,9 @@ end
         c = sinkhorn_unbalanced2(μ, ν, C, lambda, lambda, eps)
         c_pot = POT.sinkhorn_unbalanced2(μ, ν, C, eps, lambda)
 
-        @test c ≈ c_pot atol=1e-9
+        @test c ≈ c_pot atol = 1e-9
     end
 end
-
 
 @testset "stabilized sinkhorn" begin
     M = 250
@@ -147,16 +146,16 @@ end
 
     @testset "example" begin
         # create two uniform histograms
-        μ = fill(1/M, M)
-        ν = fill(1/N, N)
+        μ = fill(1 / M, M)
+        ν = fill(1 / N, N)
 
         # create random cost matrix
-        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims = 2)
+        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
 
         # compute optimal transport map (Julia implementation + POT)
         eps = 0.01
         γ = sinkhorn_stabilized(μ, ν, C, eps)
-        γ_pot = POT.sinkhorn(μ, ν, C, eps, method = "sinkhorn_stabilized")
+        γ_pot = POT.sinkhorn(μ, ν, C, eps; method="sinkhorn_stabilized")
         @test norm(γ - γ_pot, Inf) < 1e-9
     end
 end


### PR DESCRIPTION
Now that we see more activity and contributions in this repository, I think it would be good to adopt some style guide. This helps to keep the code base consistent and, in my opinion, increases readability and reduces mental overhead.

I just chose [BlueStyle](https://github.com/invenia/BlueStyle) here since it is used in most projects I contribute to. An other popular style for Julia is YAS. I would be fine with it as well, I think a main criterion should just be that is supported by [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl) since this makes it much easier to format code correctly.

Speaking about convenience, I also added a configuration for JuliaFormatter such that one can just run `format(path_to_repo)` to re-format the codebase correctly (actually, that's what I did when putting together the PR). Moreover, I added a Github action that will automatically check and report if PRs are formatted correctly. It will even post suggestions with format fixes (if required) which is even more convenient.

What do you think, @zsteve @davibarreira?