### PR TITLE
Add pre-computed map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OptimalTransport"
 uuid = "7e02d93a-ae51-4f58-b602-d97af76e3b33"
 authors = ["zsteve <stephenz@student.unimelb.edu.au>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,10 @@ Random.seed!(100)
     @test dot(C, P) ≈ cost atol=1e-5
     @test MOI.get(lp, MOI.TerminationStatus()) == MOI.OPTIMAL
     @test cost ≈ pot_cost atol=1e-5
+
+    # ensure that provided map is used
+    cost2 = emd2(similar(μ), similar(ν), C, lp; map=P)
+    @test cost2 ≈ cost
 end
 
 @testset "entropically regularized transport" begin
@@ -65,6 +69,10 @@ end
         c = sinkhorn2(μ, ν, C, eps)
         c_pot = POT.sinkhorn2(μ, ν, C, eps)
         @test c ≈ c_pot atol=1e-9
+
+        # ensure that provided map is used
+        c2 = sinkhorn2(similar(μ), similar(ν), C, rand(); map=γ)
+        @test c2 ≈ c
     end
 
     # different element type
@@ -137,6 +145,10 @@ end
         c_pot = POT.sinkhorn_unbalanced2(μ, ν, C, eps, lambda)
 
         @test c ≈ c_pot atol=1e-9
+
+        # ensure that provided map is used
+        c2 = sinkhorn_unbalanced2(similar(μ), similar(ν), C, rand(), rand(), rand(); map=γ)
+        @test c2 ≈ c
     end
 end
 


### PR DESCRIPTION
This PR adds a `map` keyword argument that allows to specify pre-computed optimal transport maps when computing the optimal transport cost.

I suggested this approach in https://github.com/zsteve/OptimalTransport.jl/pull/45 to avoid having to solve the optimal transport problem twice. The approach is used, e.g., also in Statistics for [std](https://docs.julialang.org/en/v1/stdlib/Statistics/#Statistics.std) and [var](https://docs.julialang.org/en/v1/stdlib/Statistics/#Statistics.var).

I am not sure if it would be better to use the name `plan` for the keyword argument. It's fine with me either way, I went for `map` since it seems other docstrings in this package mostly use the term `map`. In any case, I think we should try to be somewhat consistent throughout the package.