### PR TITLE
Test quadratic optimal transport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,7 @@ Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,9 @@ Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/src/OptimalTransport.jl
+++ b/src/OptimalTransport.jl
@@ -115,8 +115,9 @@ function emd2(μ, ν, C, optimizer; map=nothing)
         # check dimensions
         size(C) == (length(μ), length(ν)) ||
             error("cost matrix `C` must be of size `(length(μ), length(ν))`")
-        size(map) == size(C) ||
-            error("optimal transport map `map` and cost matrix `C` must be of the same size")
+        size(map) == size(C) || error(
+            "optimal transport map `map` and cost matrix `C` must be of the same size",
+        )
         map
     end
     return dot(γ, C)
@@ -225,8 +226,9 @@ function sinkhorn2(μ, ν, C, ε; map=nothing, kwargs...)
         # check dimensions
         size(C) == (length(μ), length(ν)) ||
             error("cost matrix `C` must be of size `(length(μ), length(ν))`")
-        size(map) == size(C) ||
-            error("optimal transport map `map` and cost matrix `C` must be of the same size")
+        size(map) == size(C) || error(
+            "optimal transport map `map` and cost matrix `C` must be of the same size",
+        )
         map
     end
     return dot(γ, C)
@@ -328,8 +330,9 @@ function sinkhorn_unbalanced2(μ, ν, C, λ1, λ2, ε; map=nothing, kwargs...)
         # check dimensions
         size(C) == (length(μ), length(ν)) ||
             error("cost matrix `C` must be of size `(length(μ), length(ν))`")
-        size(map) == size(C) ||
-            error("optimal transport map `map` and cost matrix `C` must be of the same size")
+        size(map) == size(C) || error(
+            "optimal transport map `map` and cost matrix `C` must be of the same size",
+        )
         map
     end
     return dot(γ, C)

--- a/src/pot.jl
+++ b/src/pot.jl
@@ -154,4 +154,10 @@ function sinkhorn_unbalanced2(
     )[1]
 end
 
+function smooth_ot_dual(
+    mu, nu, C, eps, reg_type = "l2", method = "L-BFGS-B", tol = 1e-9, max_iter = 500, verbose = false
+)
+    return pot.smooth.smooth_ot_dual(nu, mu, PyReverseDims(C), eps, reg_type = reg_type, method = method, stopThr = tol, numItermax = max_iter)'
+end
+
 end

--- a/src/pot.jl
+++ b/src/pot.jl
@@ -155,9 +155,18 @@ function sinkhorn_unbalanced2(
 end
 
 function smooth_ot_dual(
-    mu, nu, C, eps, reg_type = "l2", method = "L-BFGS-B", tol = 1e-9, max_iter = 500, verbose = false
+    mu, nu, C, eps; reg_type="l2", method="L-BFGS-B", tol=1e-9, max_iter=500, verbose=false
 )
-    return pot.smooth.smooth_ot_dual(nu, mu, PyReverseDims(C), eps, reg_type = reg_type, method = method, stopThr = tol, numItermax = max_iter)'
+    return pot.smooth.smooth_ot_dual(
+        nu,
+        mu,
+        PyReverseDims(C),
+        eps;
+        reg_type=reg_type,
+        method=method,
+        stopThr=tol,
+        numItermax=max_iter,
+    )'
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,7 @@ end
         # compute optimal transport map (Julia implementation + POT)
         eps = 0.25
         γ = quadreg(μ, ν, C, eps)
-        γ_pot = sparse(POT.smooth_ot_dual(μ, ν, C, eps; max_iter = 5000))
+        γ_pot = sparse(POT.smooth_ot_dual(μ, ν, C, eps; max_iter=5000))
         # need to use a larger tolerance here because of a quirk with the POT solver 
         @test norm(γ - γ_pot, Inf) < 1e-4
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -185,10 +185,10 @@ end
         C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
 
         # compute optimal transport map (Julia implementation + POT)
-        eps = 0.5
+        eps = 0.25
         γ = quadreg(μ, ν, C, eps)
-        γ_pot = sparse(POT.smooth_ot_dual(μ, ν, C, eps))
+        γ_pot = sparse(POT.smooth_ot_dual(μ, ν, C, eps; max_iter = 5000))
         # need to use a larger tolerance here because of a quirk with the POT solver 
-        @test norm(γ - γ_pot, Inf) < 0.5e-4 
+        @test norm(γ - γ_pot, Inf) < 1e-4
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Distances
 using PyCall
 using Tulip
 using MathOptInterface
+using SparseArrays
 
 using LinearAlgebra
 using Random
@@ -169,5 +170,25 @@ end
         γ = sinkhorn_stabilized(μ, ν, C, eps)
         γ_pot = POT.sinkhorn(μ, ν, C, eps; method="sinkhorn_stabilized")
         @test norm(γ - γ_pot, Inf) < 1e-9
+    end
+end
+
+@testset "quadratic optimal transport" begin
+    M = 250
+    N = 200
+    @testset "example" begin
+        # create two uniform histograms
+        μ = fill(1 / M, M)
+        ν = fill(1 / N, N)
+
+        # create random cost matrix
+        C = pairwise(SqEuclidean(), rand(1, M), rand(1, N); dims=2)
+
+        # compute optimal transport map (Julia implementation + POT)
+        eps = 0.5
+        γ = quadreg(μ, ν, C, eps)
+        γ_pot = sparse(POT.smooth_ot_dual(μ, ν, C, eps))
+        # need to use a larger tolerance here because of a quirk with the POT solver 
+        @test norm(γ - γ_pot, Inf) < 0.5e-4 
     end
 end


### PR DESCRIPTION
I've added a test for `quadreg()`. As with the other functions, I compare against the output of POT. The relevant function here is `smooth_ot_dual` from POT, and I've needed to implement another wrapper for it. (I agree that eventually it would be nice to strip the python dependencies, but we can talk about how to do testing in #42). 